### PR TITLE
HelpCommand: Update link to user guide

### DIFF
--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -15,7 +15,7 @@ import seedu.address.commons.core.LogsCenter;
  */
 public class HelpWindow extends UiPart<Stage> {
 
-    public static final String USERGUIDE_URL = "https://se-education.org/addressbook-level3/UserGuide.html";
+    public static final String USERGUIDE_URL = "https://ay2526s2-cs2103t-t17-4.github.io/tp/UserGuide.html";
     public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);


### PR DESCRIPTION
## Summary
Update the HelpCommand to point to the latest user guide link.

## Changes
- Updated URL used in HelpCommand
- Ensured link directs to the correct, latest user guide

## Why
The previous link was outdated and could mislead users or point to incorrect documentation.

## Testing
- Triggered help command and verified updated link
- Confirmed link opens correct user guide

Fixes #55 