### PR TITLE
SortCommand: Add priority-based sorting feature

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SortPriorityCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortPriorityCommand.java
@@ -1,0 +1,63 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ORDER;
+
+import java.util.Comparator;
+
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+/**
+ * Sorts all candidates in the address book by priority.
+ */
+public class SortPriorityCommand extends Command {
+
+    public static final String COMMAND_WORD = "sort"; // Preamble is pr
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " pr: Sorts candidates by priority.\n"
+            + "Secondary sorts by Date Added (descending) and Name (alphabetically).\n"
+            + "Parameters: " + PREFIX_ORDER + "ORDER\n"
+            + "Example: " + COMMAND_WORD + " pr " + PREFIX_ORDER + "desc";
+
+    public static final String MESSAGE_SUCCESS = "Sorted all candidates by priority status.";
+    public static final String MESSAGE_EMPTY_ADDRESS_BOOK = "The address book is currently empty. Nothing to sort.";
+
+    private final boolean isAscending;
+
+    /**
+     * @param isAscending whether to sort high priority to the top (true) or bottom (false).
+     */
+    public SortPriorityCommand(boolean isAscending) {
+        this.isAscending = isAscending;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        if (model.getAddressBook().getPersonList().isEmpty()) {
+            return new CommandResult(MESSAGE_EMPTY_ADDRESS_BOOK);
+        }
+
+        Comparator<Person> comparator = Comparator.comparing((Person p) -> p.getPriority().isPriority ? 0 : 1)
+                .thenComparing(Person::getDateAdded, Comparator.reverseOrder())
+                .thenComparing(p -> p.getName().fullName);
+
+        if (!isAscending) {
+            comparator = Comparator.comparing((Person p) -> p.getPriority().isPriority ? 1 : 0)
+                    .thenComparing(Person::getDateAdded, Comparator.reverseOrder())
+                    .thenComparing(p -> p.getName().fullName);
+        }
+
+        model.sortFilteredPersonList(comparator);
+
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof SortPriorityCommand // instanceof handles nulls
+                && isAscending == ((SortPriorityCommand) other).isAscending); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -20,7 +20,7 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.RejectCommand;
 import seedu.address.logic.commands.RemoveCommand;
-import seedu.address.logic.commands.SortDateCommand;
+import seedu.address.logic.commands.SortPriorityCommand;
 import seedu.address.logic.commands.TagCommand;
 import seedu.address.logic.commands.TagPoolCommand;
 import seedu.address.logic.commands.UndoCommand;
@@ -88,8 +88,8 @@ public class AddressBookParser {
         case FilterCommand.COMMAND_WORD:
             return new FilterCommandParser().parse(arguments);
 
-        case SortDateCommand.COMMAND_WORD:
-            return new SortDateCommandParser().parse(arguments);
+        case SortPriorityCommand.COMMAND_WORD:
+            return new SortCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
             if (!arguments.trim().isEmpty()) {

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -1,0 +1,41 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new SortDateCommand or SortPriorityCommand object
+ */
+public class SortCommandParser implements Parser<Command> {
+
+    public static final String MESSAGE_INVALID_SORT_TYPE =
+            "Invalid sort type. Please use 'sort date' or 'sort pr'.";
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the Sort commands
+     * and returns a Command object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public Command parse(String args) throws ParseException {
+        // We peek at the first word of the arguments to see if it's 'date' or 'pr'
+        String strippedArgs = args.trim();
+        if (strippedArgs.toLowerCase().startsWith("date")) {
+            return new SortDateCommandParser().parse(args);
+        } else if (strippedArgs.toLowerCase().startsWith("pr")) {
+            return new SortPriorityCommandParser().parse(args);
+        } else {
+            // Alternatively, delegate to SortDateCommandParser if not "pr",
+            // but throwing an error for invalid sort type is better.
+            if (!strippedArgs.isEmpty()) {
+                String firstWord = strippedArgs.split("\\s+")[0].toLowerCase();
+                if (firstWord.equals("date")) {
+                    return new SortDateCommandParser().parse(args);
+                } else if (firstWord.equals("pr")) {
+                    return new SortPriorityCommandParser().parse(args);
+                }
+            }
+            throw new ParseException(MESSAGE_INVALID_SORT_TYPE);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/SortPriorityCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortPriorityCommandParser.java
@@ -1,0 +1,48 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ORDER;
+
+import seedu.address.logic.commands.SortPriorityCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new SortPriorityCommand object
+ */
+public class SortPriorityCommandParser implements Parser<SortPriorityCommand> {
+
+    public static final String MESSAGE_INVALID_ORDER =
+            "Invalid sort order. Please use 'asc' for oldest-first or 'desc' for newest-first.";
+
+    public static final String MESSAGE_INVALID_FORMAT =
+            "Invalid command format! \nFormat: sort pr \nExample: sort pr";
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the SortPriorityCommand
+     * and returns a SortPriorityCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public SortPriorityCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_ORDER);
+
+        // Preamble must be exactly "pr"
+        String preamble = argMultimap.getPreamble().trim();
+        if (!preamble.toLowerCase().equals("pr")) {
+            throw new ParseException(MESSAGE_INVALID_FORMAT);
+        }
+
+        if (!argMultimap.getValue(PREFIX_ORDER).isPresent()) {
+            throw new ParseException(MESSAGE_INVALID_FORMAT);
+        }
+
+        String orderStr = argMultimap.getValue(PREFIX_ORDER).get().trim().toLowerCase();
+
+        if (orderStr.equals("asc")) {
+            return new SortPriorityCommand(true);
+        } else if (orderStr.equals("desc")) {
+            return new SortPriorityCommand(false);
+        } else {
+            throw new ParseException(MESSAGE_INVALID_ORDER);
+        }
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/SortPriorityCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortPriorityCommandTest.java
@@ -1,0 +1,116 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+
+public class SortPriorityCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_sortPriorityAscending_success() {
+        SortPriorityCommand sortPriorityCommand = new SortPriorityCommand(true);
+        String expectedMessage = SortPriorityCommand.MESSAGE_SUCCESS;
+
+        expectedModel.sortFilteredPersonList(
+                java.util.Comparator.comparing((Person p) -> p.getPriority().isPriority ? 0 : 1)
+                                    .thenComparing(Person::getDateAdded, java.util.Comparator.reverseOrder())
+                                    .thenComparing(p -> p.getName().fullName)
+        );
+
+        assertCommandSuccess(sortPriorityCommand, model, expectedMessage, expectedModel);
+        assertEquals(expectedModel.getFilteredPersonList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_sortPriorityDescending_success() {
+        SortPriorityCommand sortPriorityCommand = new SortPriorityCommand(false);
+        String expectedMessage = SortPriorityCommand.MESSAGE_SUCCESS;
+
+        expectedModel.sortFilteredPersonList(
+                java.util.Comparator.comparing((Person p) -> p.getPriority().isPriority ? 1 : 0)
+                                    .thenComparing(Person::getDateAdded, java.util.Comparator.reverseOrder())
+                                    .thenComparing(p -> p.getName().fullName)
+        );
+
+        assertCommandSuccess(sortPriorityCommand, model, expectedMessage, expectedModel);
+        assertEquals(expectedModel.getFilteredPersonList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_emptyAddressBook_showsEmptyMessage() {
+        Model emptyModel = new ModelManager();
+        SortPriorityCommand sortPriorityCommand = new SortPriorityCommand(true);
+
+        CommandResult result = sortPriorityCommand.execute(emptyModel);
+        assertEquals(SortPriorityCommand.MESSAGE_EMPTY_ADDRESS_BOOK, result.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_sortSecondary_success() {
+        // Create candidates with identical priority but different dates
+        Person aPerson = new PersonBuilder().withName("Alice").withPhone("11111111")
+                .withEmail("a@a.com").withDateAdded("01/01/2024 10:00 +0800").withPriority("yes").build();
+        Person zPerson = new PersonBuilder().withName("Zack").withPhone("22222222")
+                .withEmail("z@z.com").withDateAdded("02/01/2024 10:00 +0800").withPriority("yes").build();
+        Person cPerson = new PersonBuilder().withName("Charlie").withPhone("33333333")
+                .withEmail("c@c.com").withDateAdded("01/01/2024 10:00 +0800").withPriority("yes").build();
+        Person dPerson = new PersonBuilder().withName("Dan").withPhone("44444444")
+                .withEmail("d@d.com").withDateAdded("01/01/2024 10:00 +0800").withPriority("no").build();
+
+        Model customModel = new ModelManager();
+        customModel.addPerson(aPerson);
+        customModel.addPerson(cPerson);
+        customModel.addPerson(zPerson);
+        customModel.addPerson(dPerson);
+
+        SortPriorityCommand sortPriorityCommand = new SortPriorityCommand(true);
+        sortPriorityCommand.execute(customModel);
+
+        assertEquals("Zack", customModel.getFilteredPersonList().get(0).getName().fullName); // new date first
+        assertEquals("Alice", customModel.getFilteredPersonList().get(1).getName().fullName); // same date, alphabetical
+        assertEquals("Charlie", customModel.getFilteredPersonList().get(2).getName().fullName);
+        assertEquals("Dan", customModel.getFilteredPersonList().get(3).getName().fullName); // no priority
+    }
+
+    @Test
+    public void equals() {
+        SortPriorityCommand sortAscFirst = new SortPriorityCommand(true);
+        SortPriorityCommand sortAscSecond = new SortPriorityCommand(true);
+        SortPriorityCommand sortDesc = new SortPriorityCommand(false);
+
+        // same object -> returns true
+        assertTrue(sortAscFirst.equals(sortAscFirst));
+
+        // same values -> returns true
+        assertTrue(sortAscFirst.equals(sortAscSecond));
+
+        // different types -> returns false
+        assertFalse(sortAscFirst.equals(1));
+
+        // null -> returns false
+        assertFalse(sortAscFirst.equals(null));
+
+        // different values -> returns false
+        assertFalse(sortAscFirst.equals(sortDesc));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -1,0 +1,39 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.SortDateCommand;
+import seedu.address.logic.commands.SortPriorityCommand;
+
+public class SortCommandParserTest {
+
+    private SortCommandParser parser = new SortCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsCommand() {
+        // Sort priority command
+        assertParseSuccess(parser, "pr o/asc", new SortPriorityCommand(true));
+        assertParseSuccess(parser, "pr o/desc", new SortPriorityCommand(false));
+
+        // Sort date command
+        assertParseSuccess(parser, "date o/asc", new SortDateCommand(true));
+        assertParseSuccess(parser, "date o/desc", new SortDateCommand(false));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        // Invalid sort type
+        assertParseFailure(parser, "invalid", SortCommandParser.MESSAGE_INVALID_SORT_TYPE);
+        assertParseFailure(parser, "", SortCommandParser.MESSAGE_INVALID_SORT_TYPE);
+
+        // Invalid date args
+        assertParseFailure(parser, "date o/invalid", SortDateCommandParser.MESSAGE_INVALID_ORDER);
+
+        // Invalid pr args
+        assertParseFailure(parser, "pr", SortPriorityCommandParser.MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "pr o/invalid", SortPriorityCommandParser.MESSAGE_INVALID_ORDER);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/SortPriorityCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortPriorityCommandParserTest.java
@@ -1,0 +1,36 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.SortPriorityCommand;
+
+public class SortPriorityCommandParserTest {
+
+    private SortPriorityCommandParser parser = new SortPriorityCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsSortPriorityCommand() {
+
+        // explicit ascending
+        assertParseSuccess(parser, "pr o/asc", new SortPriorityCommand(true));
+
+        // explicit descending
+        assertParseSuccess(parser, "pr o/desc", new SortPriorityCommand(false));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        // missing order prefix
+        assertParseFailure(parser, "pr", SortPriorityCommandParser.MESSAGE_INVALID_FORMAT);
+
+        // invalid preamble
+        assertParseFailure(parser, "abc", SortPriorityCommandParser.MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "prr", SortPriorityCommandParser.MESSAGE_INVALID_FORMAT);
+
+        // invalid order
+        assertParseFailure(parser, "pr o/xyz", SortPriorityCommandParser.MESSAGE_INVALID_ORDER);
+    }
+}


### PR DESCRIPTION
The contact list lacks a way to surface high-
priority leads.This prevents recruiters from
quickly identifying key candidates.

Let's implement 'sort pr o/ORDER' to group
candidates by priority.

This uses a multi-tiered comparator (Priority ->
Date -> Name)to ensure a deterministic and
predictable display for the user.