### PR TITLE
FindCommand: Extend to include notes and rejections

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -14,9 +14,9 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names, phones, or emails "
-            + "contain any of the specified keywords (case-insensitive) and displays them as a list "
-            + "with index numbers.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names, phones, emails, "
+            + "notes, or rejection reasons contain any of the specified keywords (case-insensitive) "
+            + "and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice 9876 john@example.com";
 

--- a/src/main/java/seedu/address/model/person/NamePhoneEmailContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NamePhoneEmailContainsKeywordsPredicate.java
@@ -6,7 +6,8 @@ import java.util.function.Predicate;
 import seedu.address.commons.util.ToStringBuilder;
 
 /**
- * Tests that a {@code Person}'s {@code Name}, {@code Phone}, or {@code Email} matches any of the keywords given.
+ * Tests that a {@code Person}'s {@code Name}, {@code Phone}, {@code Email}, {@code Note}s,
+ * or {@code RejectionReason}s matches any of the keywords given.
  */
 public class NamePhoneEmailContainsKeywordsPredicate implements Predicate<Person> {
     private final List<String> keywords;
@@ -20,9 +21,15 @@ public class NamePhoneEmailContainsKeywordsPredicate implements Predicate<Person
         return keywords.stream()
                 .anyMatch(keyword -> {
                     String lowerCaseKeyword = keyword.toLowerCase();
-                    return person.getName().fullName.toLowerCase().contains(lowerCaseKeyword)
+                    boolean matchesBasicFields = person.getName().fullName.toLowerCase().contains(lowerCaseKeyword)
                             || person.getPhone().value.toLowerCase().contains(lowerCaseKeyword)
                             || person.getEmail().value.toLowerCase().contains(lowerCaseKeyword);
+                    boolean matchesNotes = person.getNotes().stream()
+                            .anyMatch(note -> note.heading.toLowerCase().contains(lowerCaseKeyword)
+                                    || note.content.toLowerCase().contains(lowerCaseKeyword));
+                    boolean matchesRejectionReasons = person.getRejectionReasons().stream()
+                            .anyMatch(r -> r.reason.toLowerCase().contains(lowerCaseKeyword));
+                    return matchesBasicFields || matchesNotes || matchesRejectionReasons;
                 });
     }
 

--- a/src/test/java/seedu/address/model/person/NamePhoneEmailContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NamePhoneEmailContainsKeywordsPredicateTest.java
@@ -98,6 +98,44 @@ public class NamePhoneEmailContainsKeywordsPredicateTest {
     }
 
     @Test
+    public void test_noteContainsKeyword_returnsTrue() {
+        // Keyword matches note heading
+        NamePhoneEmailContainsKeywordsPredicate predicate =
+                new NamePhoneEmailContainsKeywordsPredicate(Collections.singletonList("interview"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice")
+                .withNotes(List.of(new Note("interview", "went well"))).build()));
+
+        // Keyword matches note content
+        predicate = new NamePhoneEmailContainsKeywordsPredicate(Collections.singletonList("outstanding"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice")
+                .withNotes(List.of(new Note("Performance", "outstanding candidate"))).build()));
+
+        // Case-insensitive note match
+        predicate = new NamePhoneEmailContainsKeywordsPredicate(Collections.singletonList("TECH"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice")
+                .withNotes(List.of(new Note("Tech Round", "passed"))).build()));
+    }
+
+    @Test
+    public void test_rejectionReasonContainsKeyword_returnsTrue() {
+        // Keyword matches rejection reason
+        NamePhoneEmailContainsKeywordsPredicate predicate =
+                new NamePhoneEmailContainsKeywordsPredicate(Collections.singletonList("overqualified"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice")
+                .withRejectionReasons("overqualified for the role").build()));
+
+        // Partial match in rejection reason
+        predicate = new NamePhoneEmailContainsKeywordsPredicate(Collections.singletonList("skills"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice")
+                .withRejectionReasons("insufficient skills").build()));
+
+        // Case-insensitive rejection reason match
+        predicate = new NamePhoneEmailContainsKeywordsPredicate(Collections.singletonList("CULTURE"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice")
+                .withRejectionReasons("culture fit issues").build()));
+    }
+
+    @Test
     public void toStringMethod() {
         List<String> keywords = List.of("keyword1", "keyword2");
         NamePhoneEmailContainsKeywordsPredicate predicate = new NamePhoneEmailContainsKeywordsPredicate(keywords);


### PR DESCRIPTION
Fixes #86 

# Summary
- Extended `find` command to search across candidate notes and rejection reasons, in addition to the existing name, phone, and email fields
- Updated `NamePhoneEmailContainsKeywordsPredicate` to match note headings, note content, and rejection reason text
- Updated `FindCommand` usage message to reflect the expanded search scope

# Changes
- `NamePhoneEmailContainsKeywordsPredicate.java` — predicate now checks notes and rejection reasons
- `FindCommand.java` — updated `MESSAGE_USAGE` string

# Test plan
- [ ] `find <keyword>` returns candidates where keyword matches a note heading or content
- [ ] `find <keyword>` returns candidates where keyword matches a rejection reason
- [ ] Existing name/phone/email search still works as before
- [ ] `NamePhoneEmailContainsKeywordsPredicateTest` passes
