### PR TITLE
refactor: Address PR #93 review comments and add tests

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.person.Person;
@@ -20,8 +21,8 @@ public class CommandResult {
     /** The application should exit. */
     private final boolean exit;
 
-    /** The candidate to display in the detail panel. Null if no candidate to show. */
-    private final Person selectedPerson;
+    /** The candidate to display in the detail panel. Empty if no candidate to show. */
+    private final Optional<Person> selectedPerson;
 
     /**
      * Constructs a {@code CommandResult} with the specified fields.
@@ -30,7 +31,7 @@ public class CommandResult {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.exit = exit;
-        this.selectedPerson = null;
+        this.selectedPerson = Optional.empty();
     }
 
     /**
@@ -48,7 +49,7 @@ public class CommandResult {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = false;
         this.exit = false;
-        this.selectedPerson = selectedPerson;
+        this.selectedPerson = Optional.of(selectedPerson);
     }
 
     public String getFeedbackToUser() {
@@ -64,10 +65,10 @@ public class CommandResult {
     }
 
     public boolean isShowPerson() {
-        return selectedPerson != null;
+        return selectedPerson.isPresent();
     }
 
-    public Person getSelectedPerson() {
+    public Optional<Person> getSelectedPerson() {
         return selectedPerson;
     }
 
@@ -86,7 +87,7 @@ public class CommandResult {
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
                 && showHelp == otherCommandResult.showHelp
                 && exit == otherCommandResult.exit
-                && Objects.equals(selectedPerson, otherCommandResult.selectedPerson);
+                && selectedPerson.equals(otherCommandResult.selectedPerson);
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/CandidateDetailPanel.java
+++ b/src/main/java/seedu/address/ui/CandidateDetailPanel.java
@@ -62,6 +62,13 @@ public class CandidateDetailPanel extends UiPart<Region> {
         detailContent.setVisible(true);
         detailContent.setManaged(true);
 
+        renderBasicFields(person);
+        renderTags(person);
+        renderNotes(person.getNotes());
+        renderRejections(person.getRejectionReasons());
+    }
+
+    private void renderBasicFields(Person person) {
         detailName.setText(person.getName().fullName);
         detailPhone.setText("Phone: " + person.getPhone().value);
         detailEmail.setText("Email: " + person.getEmail().value);
@@ -69,7 +76,9 @@ public class CandidateDetailPanel extends UiPart<Region> {
         detailStatus.setText("Status: " + formatStatus(person.getStatus()));
         detailPriority.setText("Priority: " + (person.getPriority().isPriority ? "⭐ High" : "Normal"));
         detailDateAdded.setText("Added: " + person.getDateAdded().getDisplayFormat());
+    }
 
+    private void renderTags(Person person) {
         detailTags.getChildren().clear();
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
@@ -78,38 +87,40 @@ public class CandidateDetailPanel extends UiPart<Region> {
                     tagLabel.getStyleClass().add("detail-tag");
                     detailTags.getChildren().add(tagLabel);
                 });
+    }
 
+    private void renderNotes(List<Note> notes) {
         detailNotes.getChildren().clear();
-        List<Note> notes = person.getNotes();
         if (notes.isEmpty()) {
             detailNotes.getChildren().add(makeFieldLabel("No notes recorded."));
-        } else {
-            IntStream.range(0, notes.size()).forEach(i -> {
-                Note note = notes.get(i);
-                VBox noteBox = new VBox(2);
-                noteBox.getStyleClass().add("detail-note-box");
-                Label heading = new Label((i + 1) + ". " + note.heading);
-                heading.getStyleClass().add("detail-note-heading");
-                heading.setWrapText(true);
-                Label content = new Label(note.content);
-                content.getStyleClass().add("detail-field");
-                content.setWrapText(true);
-                noteBox.getChildren().addAll(heading, content);
-                detailNotes.getChildren().add(noteBox);
-            });
+            return;
         }
+        IntStream.range(0, notes.size()).forEach(i -> {
+            Note note = notes.get(i);
+            VBox noteBox = new VBox(2);
+            noteBox.getStyleClass().add("detail-note-box");
+            Label heading = new Label((i + 1) + ". " + note.heading);
+            heading.getStyleClass().add("detail-note-heading");
+            heading.setWrapText(true);
+            Label content = new Label(note.content);
+            content.getStyleClass().add("detail-field");
+            content.setWrapText(true);
+            noteBox.getChildren().addAll(heading, content);
+            detailNotes.getChildren().add(noteBox);
+        });
+    }
 
+    private void renderRejections(List<RejectionReason> reasons) {
         detailRejections.getChildren().clear();
-        List<RejectionReason> reasons = person.getRejectionReasons();
         if (reasons.isEmpty()) {
             detailRejections.getChildren().add(makeFieldLabel("No rejections recorded."));
-        } else {
-            IntStream.range(0, reasons.size()).forEach(i -> {
-                Label reasonLabel = makeFieldLabel((i + 1) + ". " + reasons.get(i).reason);
-                reasonLabel.setWrapText(true);
-                detailRejections.getChildren().add(reasonLabel);
-            });
+            return;
         }
+        IntStream.range(0, reasons.size()).forEach(i -> {
+            Label reasonLabel = makeFieldLabel((i + 1) + ". " + reasons.get(i).reason);
+            reasonLabel.setWrapText(true);
+            detailRejections.getChildren().add(reasonLabel);
+        });
     }
 
     private Label makeFieldLabel(String text) {
@@ -121,12 +132,14 @@ public class CandidateDetailPanel extends UiPart<Region> {
 
     private String formatStatus(Status status) {
         switch (status) {
+        case NONE:
+            return "Active";
         case REJECTED:
             return "Rejected";
         case ARCHIVED:
             return "Archived";
         default:
-            return "Active";
+            throw new IllegalArgumentException("Unknown status: " + status);
         }
     }
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -193,9 +193,7 @@ public class MainWindow extends UiPart<Stage> {
                 handleExit();
             }
 
-            if (commandResult.isShowPerson()) {
-                candidateDetailPanel.showPerson(commandResult.getSelectedPerson());
-            }
+            commandResult.getSelectedPerson().ifPresent(candidateDetailPanel::showPerson);
 
             return commandResult;
         } catch (CommandException | ParseException e) {

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -4,6 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -33,6 +36,9 @@ public class CommandResultTest {
 
         // different exit value -> returns false
         assertFalse(commandResult.equals(new CommandResult("feedback", false, true)));
+
+        // different selectedPerson value -> returns false
+        assertFalse(commandResult.equals(new CommandResult("feedback", ALICE)));
     }
 
     @Test
@@ -50,6 +56,9 @@ public class CommandResultTest {
 
         // different exit value -> returns different hashcode
         assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true).hashCode());
+
+        // different selectedPerson value -> returns different hashcode
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", ALICE).hashCode());
     }
 
     @Test
@@ -59,5 +68,19 @@ public class CommandResultTest {
                 + commandResult.getFeedbackToUser() + ", showHelp=" + commandResult.isShowHelp()
                 + ", exit=" + commandResult.isExit() + "}";
         assertEquals(expected, commandResult.toString());
+    }
+
+    @Test
+    public void isShowPerson_withPerson_returnsTrue() {
+        CommandResult commandResult = new CommandResult("feedback", ALICE);
+        assertTrue(commandResult.isShowPerson());
+        assertEquals(Optional.of(ALICE), commandResult.getSelectedPerson());
+    }
+
+    @Test
+    public void isShowPerson_withoutPerson_returnsFalse() {
+        CommandResult commandResult = new CommandResult("feedback");
+        assertFalse(commandResult.isShowPerson());
+        assertEquals(Optional.empty(), commandResult.getSelectedPerson());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ShowCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ShowCommandTest.java
@@ -1,0 +1,71 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for {@code ShowCommand}.
+ */
+public class ShowCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() throws CommandException {
+        Person personToShow = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        ShowCommand showCommand = new ShowCommand(INDEX_FIRST_PERSON);
+
+        CommandResult result = showCommand.execute(model);
+
+        assertEquals(String.format(ShowCommand.MESSAGE_SUCCESS, personToShow.getName().fullName),
+                result.getFeedbackToUser());
+        assertTrue(result.isShowPerson());
+        assertTrue(result.getSelectedPerson().isPresent());
+        assertEquals(personToShow, result.getSelectedPerson().get());
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        ShowCommand showCommand = new ShowCommand(outOfBoundIndex);
+
+        assertCommandFailure(showCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        ShowCommand showFirstCommand = new ShowCommand(INDEX_FIRST_PERSON);
+        ShowCommand showSecondCommand = new ShowCommand(INDEX_SECOND_PERSON);
+
+        // same object -> returns true
+        assertTrue(showFirstCommand.equals(showFirstCommand));
+
+        // same values -> returns true
+        ShowCommand showFirstCommandCopy = new ShowCommand(INDEX_FIRST_PERSON);
+        assertTrue(showFirstCommand.equals(showFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(showFirstCommand.equals(1.0f));
+
+        // null -> returns false
+        assertFalse(showFirstCommand.equals(null));
+
+        // different index -> returns false
+        assertFalse(showFirstCommand.equals(showSecondCommand));
+    }
+}


### PR DESCRIPTION
- Use Optional<Person> in CommandResult instead of nullable field
- Use Optional.isPresent() as single source of truth for isShowPerson()
- Extract renderBasicFields/renderTags/renderNotes/renderRejections from showPerson() to improve SLAP
- Handle all Status enum cases explicitly in formatStatus()
- Add ShowCommandTest with valid index, invalid index, and equals tests
- Update CommandResultTest to cover Optional<Person> constructor, isShowPerson, getSelectedPerson, equals and hashcode