### PR TITLE
docs: Add RejectCommand sequence diagram

### DIFF
--- a/docs/diagrams/RejectSequenceDiagram.puml
+++ b/docs/diagrams/RejectSequenceDiagram.puml
@@ -1,0 +1,113 @@
+@startuml
+!include style.puml
+skinparam ArrowFontStyle plain
+
+box Logic LOGIC_COLOR_T1
+participant ":LogicManager" as LogicManager LOGIC_COLOR
+participant ":AddressBookParser" as AddressBookParser LOGIC_COLOR
+participant ":RejectCommandParser" as RejectCommandParser LOGIC_COLOR
+participant "d:RejectCommand" as RejectCommand LOGIC_COLOR
+participant "r:CommandResult" as CommandResult LOGIC_COLOR
+end box
+
+box Model MODEL_COLOR_T1
+participant "m:Model" as Model MODEL_COLOR
+end box
+
+[-> LogicManager : execute("reject 1 r/Failed technical interview")
+activate LogicManager
+
+LogicManager -> AddressBookParser : parseCommand("reject 1 r/Failed technical interview")
+activate AddressBookParser
+
+create RejectCommandParser
+AddressBookParser -> RejectCommandParser
+activate RejectCommandParser
+
+RejectCommandParser --> AddressBookParser
+deactivate RejectCommandParser
+
+AddressBookParser -> RejectCommandParser : parse("1 r/Failed technical interview")
+activate RejectCommandParser
+
+RejectCommandParser -> RejectCommandParser : parseIndex("1")
+activate RejectCommandParser #C8C8FA
+RejectCommandParser --> RejectCommandParser : index
+deactivate RejectCommandParser
+
+RejectCommandParser -> RejectCommandParser : validate reason
+activate RejectCommandParser #C8C8FA
+
+alt#LightCoral #FFCCCC reason prefix missing
+    RejectCommandParser --> AddressBookParser : throw ParseException\n("Invalid format")
+end
+
+alt#LightCoral #FFCCCC invalid reason
+    RejectCommandParser --> AddressBookParser : throw ParseException\n("Invalid reason")
+end
+
+RejectCommandParser --> RejectCommandParser
+deactivate RejectCommandParser
+
+create RejectCommand
+RejectCommandParser -> RejectCommand : RejectCommand(index, reason)
+activate RejectCommand
+
+RejectCommand --> RejectCommandParser
+deactivate RejectCommand
+
+RejectCommandParser --> AddressBookParser : d
+deactivate RejectCommandParser
+'Hidden arrow to position the destroy marker below the end of the activation bar.
+RejectCommandParser -[hidden]-> AddressBookParser
+destroy RejectCommandParser
+
+AddressBookParser --> LogicManager : d
+deactivate AddressBookParser
+
+LogicManager -> RejectCommand : execute(m)
+activate RejectCommand
+
+RejectCommand -> Model : getFilteredPersonList()
+activate Model
+
+Model --> RejectCommand : lastShownList
+deactivate Model
+
+alt#LightCoral #FFCCCC index out of range
+    RejectCommand --> LogicManager : throw CommandException\n("Index out of range")
+end
+
+alt#LightCoral #FFCCCC candidate is blacklisted
+    RejectCommand --> LogicManager : throw CommandException\n("Cannot modify blacklisted candidate")
+end
+
+RejectCommand -> RejectCommand : createRejectedPerson(person, reason)
+activate RejectCommand #C8C8FA
+note right
+  Sets status to REJECTED
+  and appends reason to
+  rejection history
+end note
+RejectCommand --> RejectCommand : rejectedPerson
+deactivate RejectCommand
+
+RejectCommand -> Model : setPerson(person, rejectedPerson)
+activate Model
+
+Model --> RejectCommand
+deactivate Model
+
+create CommandResult
+RejectCommand -> CommandResult
+activate CommandResult
+
+CommandResult --> RejectCommand
+deactivate CommandResult
+
+RejectCommand --> LogicManager : r
+deactivate RejectCommand
+
+[<--LogicManager
+deactivate LogicManager
+@enduml


### PR DESCRIPTION
Closes #107

- Adds a PlantUML sequence diagram (`RejectSequenceDiagram.puml`) illustrating the full execution flow of the `reject` command
- Shows interaction between LogicManager, AddressBookParser, RejectCommandParser, RejectCommand, and Model
- Includes alt blocks for error paths (invalid format, invalid reason, index out of range, blacklisted candidate)
