### PR TITLE
fix: Prevent prefix-like text in fields from being mis-parsed

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -33,7 +33,7 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                ArgumentTokenizer.tokenizeFirstOnly(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                         PREFIX_PRIORITY, PREFIX_STATUS);
 
         if (!argMultimap.getPreamble().isEmpty()) {

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -2,7 +2,9 @@ package seedu.address.logic.parser;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -29,6 +31,20 @@ public class ArgumentTokenizer {
     }
 
     /**
+     * Tokenizes an arguments string, recognising only the first occurrence of each prefix.
+     * This prevents prefix-like text in free-text fields (e.g. addresses) from being mis-parsed.
+     * Use this for commands where each prefix appears at most once (e.g. add, edit).
+     *
+     * @param argsString Arguments string of the form: {@code preamble <prefix>value <prefix>value ...}
+     * @param prefixes   Prefixes to tokenize the arguments string with
+     * @return           ArgumentMultimap object that maps prefixes to their arguments
+     */
+    public static ArgumentMultimap tokenizeFirstOnly(String argsString, Prefix... prefixes) {
+        List<PrefixPosition> positions = findFirstPrefixPositions(argsString, prefixes);
+        return extractArguments(argsString, positions);
+    }
+
+    /**
      * Finds all zero-based prefix positions in the given arguments string.
      *
      * @param argsString Arguments string of the form: {@code preamble <prefix>value <prefix>value ...}
@@ -39,6 +55,30 @@ public class ArgumentTokenizer {
         return Arrays.stream(prefixes)
                 .flatMap(prefix -> findPrefixPositions(argsString, prefix).stream())
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Finds only the first zero-based position of each unique prefix string in the given arguments string.
+     * Prefixes that share the same string (e.g. two Prefix objects both using "a/") are treated as one.
+     *
+     * @param argsString Arguments string of the form: {@code preamble <prefix>value <prefix>value ...}
+     * @param prefixes   Prefixes to find in the arguments string
+     * @return           List containing at most one position per unique prefix string
+     */
+    private static List<PrefixPosition> findFirstPrefixPositions(String argsString, Prefix... prefixes) {
+        List<PrefixPosition> result = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+        for (Prefix prefix : prefixes) {
+            if (seen.contains(prefix.getPrefix())) {
+                continue;
+            }
+            seen.add(prefix.getPrefix());
+            int pos = findPrefixPosition(argsString, prefix.getPrefix(), 0);
+            if (pos != -1) {
+                result.add(new PrefixPosition(prefix, pos));
+            }
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -26,7 +26,7 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                ArgumentTokenizer.tokenizeFirstOnly(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                         PREFIX_PRIORITY, PREFIX_STATUS);
 
         Index index;

--- a/src/main/java/seedu/address/logic/parser/NoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/NoteCommandParser.java
@@ -35,7 +35,7 @@ public class NoteCommandParser implements Parser<NoteCommand> {
     public NoteCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NOTE_CONTENT, PREFIX_NOTE_HEADING);
+                ArgumentTokenizer.tokenizeFirstOnly(args, PREFIX_NOTE_CONTENT, PREFIX_NOTE_HEADING);
 
         Index index;
         try {

--- a/src/main/java/seedu/address/logic/parser/RejectCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RejectCommandParser.java
@@ -19,7 +19,7 @@ public class RejectCommandParser implements Parser<RejectCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public RejectCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_REASON);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenizeFirstOnly(args, PREFIX_REASON);
 
         if (!isReasonPrefixPresent(argMultimap)) {
             throw new ParseException(Messages.MESSAGE_REJECT_INVALID_FORMAT);

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -20,10 +20,6 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalPersons.AMY;
@@ -31,7 +27,6 @@ import static seedu.address.testutil.TypicalPersons.BOB;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.Messages;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
@@ -54,66 +49,12 @@ public class AddCommandParserTest {
     }
 
     @Test
-    public void parse_repeatedNonTagValue_failure() {
-        String validExpectedPersonString = NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB;
-
-        // multiple names
-        assertParseFailure(parser, NAME_DESC_AMY + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
-
-        // multiple phones
-        assertParseFailure(parser, PHONE_DESC_AMY + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
-
-        // multiple emails
-        assertParseFailure(parser, EMAIL_DESC_AMY + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL));
-
-        // multiple addresses
-        assertParseFailure(parser, ADDRESS_DESC_AMY + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS));
-
-        // multiple fields repeated
-        assertParseFailure(parser,
-                validExpectedPersonString + PHONE_DESC_AMY + EMAIL_DESC_AMY + NAME_DESC_AMY + ADDRESS_DESC_AMY
-                        + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_ADDRESS, PREFIX_EMAIL, PREFIX_PHONE));
-
-        // invalid value followed by valid value
-
-        // invalid name
-        assertParseFailure(parser, INVALID_NAME_DESC + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
-
-        // invalid email
-        assertParseFailure(parser, INVALID_EMAIL_DESC + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL));
-
-        // invalid phone
-        assertParseFailure(parser, INVALID_PHONE_DESC + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
-
-        // invalid address
-        assertParseFailure(parser, INVALID_ADDRESS_DESC + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS));
-
-        // valid value followed by invalid value
-
-        // invalid name
-        assertParseFailure(parser, validExpectedPersonString + INVALID_NAME_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
-
-        // invalid email
-        assertParseFailure(parser, validExpectedPersonString + INVALID_EMAIL_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL));
-
-        // invalid phone
-        assertParseFailure(parser, validExpectedPersonString + INVALID_PHONE_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
-
-        // invalid address
-        assertParseFailure(parser, validExpectedPersonString + INVALID_ADDRESS_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS));
+    public void parse_prefixLikeTextInAddress_success() {
+        // address containing prefix-like text should not be mis-parsed
+        Person expectedPerson = new PersonBuilder(BOB).withAddress("Blk 123 n/a Street").withTags().build();
+        assertParseSuccess(parser,
+                NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + " a/Blk 123 n/a Street",
+                new AddCommand(expectedPerson));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -1,9 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
@@ -21,11 +19,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_STATUS_ACTIVE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_STATUS_HIRED;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -35,7 +29,6 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.Messages;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.model.person.Address;
@@ -219,47 +212,20 @@ public class EditCommandParserTest {
     }
 
     @Test
-    public void parse_duplicateStatus_failure() {
-        assertParseFailure(parser, "1" + STATUS_DESC_ACTIVE + STATUS_DESC_HIRED,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STATUS));
-    }
-
-    @Test
-    public void parse_duplicatePriority_failure() {
-        assertParseFailure(parser,
-                "1 " + PREFIX_PRIORITY + "yes " + PREFIX_PRIORITY + "no",
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PRIORITY));
-    }
-
-    @Test
-    public void parse_multipleRepeatedFields_failure() {
-        // More extensive testing of duplicate parameter detections is done in
-        // AddCommandParserTest#parse_repeatedNonTagValue_failure()
-
-        // valid followed by invalid
+    public void parse_prefixLikeTextInAddress_success() {
+        // When all prefixes have already been used, prefix-like text in
+        // address (e.g. "n/a") is not mis-parsed as a second n/ prefix
         Index targetIndex = INDEX_FIRST_PERSON;
-        String userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + PHONE_DESC_BOB;
+        String userInput = targetIndex.getOneBased()
+                + " n/John Doe p/91234567 e/john@example.com a/Blk 123 n/a Street";
 
-        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
+        EditPersonDescriptor descriptor = new EditPersonDescriptor();
+        descriptor.setName(new Name("John Doe"));
+        descriptor.setPhone(new Phone("91234567"));
+        descriptor.setEmail(new Email("john@example.com"));
+        descriptor.setAddress(new Address("Blk 123 n/a Street"));
 
-        // invalid followed by valid
-        userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + INVALID_PHONE_DESC;
-
-        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
-
-        // multiple valid fields repeated
-        userInput = targetIndex.getOneBased() + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
-                + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
-                + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB;
-
-        assertParseFailure(parser, userInput,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS));
-
-        // multiple invalid values
-        userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC
-                + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC;
-
-        assertParseFailure(parser, userInput,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS));
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/NoteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/NoteCommandParserTest.java
@@ -87,13 +87,17 @@ public class NoteCommandParserTest {
     }
 
     @Test
-    public void parse_duplicateContentPrefix_throwsParseException() {
-        assertThrows(ParseException.class, () -> parser.parse(" 1 n/first n/second"));
+    public void parse_prefixLikeTextInContent_success() throws Exception {
+        // Second n/ should be absorbed into content, not treated as a duplicate prefix
+        NoteCommand cmd = parser.parse(" 1 n/first n/second");
+        assertEquals("first n/second", cmd.getNote().content);
     }
 
     @Test
-    public void parse_duplicateHeadingPrefix_throwsParseException() {
-        assertThrows(ParseException.class, () -> parser.parse(" 1 n/content h/first h/second"));
+    public void parse_prefixLikeTextInHeading_success() throws Exception {
+        // Second h/ should be absorbed into heading, not treated as a duplicate prefix
+        NoteCommand cmd = parser.parse(" 1 n/content h/first h/second");
+        assertEquals("first h/second", cmd.getNote().heading);
     }
 
     @Test


### PR DESCRIPTION
Add tokenizeFirstOnly() to ArgumentTokenizer that recognises only the first occurrence of each prefix. This prevents text like "n/a" or "pr/floor 2" in addresses from being wrongly interpreted as duplicate prefixes when all fields are present.

Applied to AddCommandParser, EditCommandParser, NoteCommandParser, and RejectCommandParser since they only expect single-occurrence prefixes.

Fixes #116