### PR TITLE
fix: Enforce minimum window size to prevent unusable UI

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -144,6 +144,8 @@ public class MainWindow extends UiPart<Stage> {
             primaryStage.setX(guiSettings.getWindowCoordinates().getX());
             primaryStage.setY(guiSettings.getWindowCoordinates().getY());
         }
+        primaryStage.setMinWidth(800);
+        primaryStage.setMinHeight(600);
     }
 
     /**


### PR DESCRIPTION
## Summary
Closes #162 

- Sets a minimum window width of 800px and height of 600px on the primary stage in `MainWindow`
- Prevents users from dragging the window to a size where the command box, candidate list, and detail panel are cut off