### PR TITLE
feat: Add list mode to tagpool command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/TagPoolCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagPoolCommand.java
@@ -7,7 +7,9 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_DELETE_TAG;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import javafx.collections.ObservableList;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
@@ -24,12 +26,15 @@ public class TagPoolCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Creates and/or deletes tags in the master tag pool.\n"
-            + "Parameters: [" + PREFIX_ADD_TAG + "TAG_TO_CREATE]... ["
+            + "To list all tags: " + COMMAND_WORD + "\n"
+            + "To create/delete: " + COMMAND_WORD + " [" + PREFIX_ADD_TAG + "TAG_TO_CREATE]... ["
             + PREFIX_DELETE_TAG + "TAG_TO_DELETE]...\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_ADD_TAG + "Frontend "
             + PREFIX_ADD_TAG + "Backend " + PREFIX_DELETE_TAG + "Intern";
 
     public static final String MESSAGE_SUCCESS = "Tag pool updated. Created: %d tag(s). Deleted: %d tag(s).";
+    public static final String MESSAGE_POOL_EMPTY = "Tag pool is empty. Use `tagpool a/TAG` to create tags.";
+    public static final String MESSAGE_POOL_LISTING = "Tag pool (%d tag%s): %s";
     public static final String MESSAGE_CONFLICT =
             "Error: Cannot create and delete the same tag ('%s') in one command.";
     public static final String MESSAGE_DUPLICATE_ADD =
@@ -39,6 +44,7 @@ public class TagPoolCommand extends Command {
 
     private final List<Tag> toAdd;
     private final List<Tag> toDelete;
+    private final boolean isListMode;
 
     /**
      * Creates a TagPoolCommand to add and/or delete the specified tags.
@@ -48,11 +54,34 @@ public class TagPoolCommand extends Command {
         requireNonNull(toDelete);
         this.toAdd = List.copyOf(toAdd);
         this.toDelete = List.copyOf(toDelete);
+        this.isListMode = false;
+    }
+
+    /**
+     * Creates a TagPoolCommand in list mode that displays all tags in the pool.
+     */
+    public TagPoolCommand() {
+        this.toAdd = List.of();
+        this.toDelete = List.of();
+        this.isListMode = true;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
+        if (isListMode) {
+            ObservableList<Tag> allTags = model.getAddressBook().getTagList();
+            if (allTags.isEmpty()) {
+                return new CommandResult(MESSAGE_POOL_EMPTY);
+            }
+            String tagNames = allTags.stream()
+                    .map(tag -> tag.tagName)
+                    .sorted(String.CASE_INSENSITIVE_ORDER)
+                    .collect(Collectors.joining(", "));
+            return new CommandResult(String.format(MESSAGE_POOL_LISTING,
+                    allTags.size(), allTags.size() == 1 ? "" : "s", tagNames));
+        }
 
         // ── Phase 1: Pre-Execution Validation (zero mutations) ──
 
@@ -140,6 +169,7 @@ public class TagPoolCommand extends Command {
             return false;
         }
         TagPoolCommand otherCommand = (TagPoolCommand) other;
-        return toAdd.equals(otherCommand.toAdd) && toDelete.equals(otherCommand.toDelete);
+        return isListMode == otherCommand.isListMode
+                && toAdd.equals(otherCommand.toAdd) && toDelete.equals(otherCommand.toDelete);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/TagPoolCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/TagPoolCommandParser.java
@@ -37,7 +37,7 @@ public class TagPoolCommandParser implements Parser<TagPoolCommand> {
         }
 
         if (addValues.isEmpty() && deleteValues.isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagPoolCommand.MESSAGE_USAGE));
+            return new TagPoolCommand();
         }
 
         if (addValues.size() + deleteValues.size() > MAX_TAGS) {

--- a/src/test/java/seedu/address/logic/commands/TagPoolCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagPoolCommandTest.java
@@ -162,18 +162,58 @@ public class TagPoolCommandTest {
     }
 
     @Test
+    public void execute_listModeEmptyPool_showsEmptyMessage() throws Exception {
+        ModelStubAcceptingTagOps model = new ModelStubAcceptingTagOps();
+
+        CommandResult result = new TagPoolCommand().execute(model);
+
+        assertEquals(TagPoolCommand.MESSAGE_POOL_EMPTY, result.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_listModePopulatedPool_showsSortedTags() throws Exception {
+        ModelStubAcceptingTagOps model = new ModelStubAcceptingTagOps();
+        model.addTag(new Tag("Frontend"));
+        model.addTag(new Tag("Backend"));
+        model.addTag(new Tag("AI"));
+
+        CommandResult result = new TagPoolCommand().execute(model);
+
+        assertEquals(String.format(TagPoolCommand.MESSAGE_POOL_LISTING, 3, "s", "AI, Backend, Frontend"),
+                result.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_listModeSingleTag_showsSingularForm() throws Exception {
+        ModelStubAcceptingTagOps model = new ModelStubAcceptingTagOps();
+        model.addTag(new Tag("OnlyTag"));
+
+        CommandResult result = new TagPoolCommand().execute(model);
+
+        assertEquals(String.format(TagPoolCommand.MESSAGE_POOL_LISTING, 1, "", "OnlyTag"),
+                result.getFeedbackToUser());
+    }
+
+    @Test
     public void equals() {
         Tag a = new Tag("Alpha");
         Tag b = new Tag("Beta");
         TagPoolCommand cmd1 = new TagPoolCommand(List.of(a), List.of(b));
         TagPoolCommand cmd2 = new TagPoolCommand(List.of(a), List.of(b));
         TagPoolCommand cmd3 = new TagPoolCommand(List.of(b), List.of(a));
+        TagPoolCommand listCmd1 = new TagPoolCommand();
+        TagPoolCommand listCmd2 = new TagPoolCommand();
 
         assertTrue(cmd1.equals(cmd1));
         assertTrue(cmd1.equals(cmd2));
         assertFalse(cmd1.equals(cmd3));
         assertFalse(cmd1.equals(null));
         assertFalse(cmd1.equals(5));
+
+        // list mode equality
+        assertTrue(listCmd1.equals(listCmd2));
+        assertFalse(listCmd1.equals(cmd1));
+        assertFalse(cmd1.equals(listCmd1));
     }
 
     // ─── Model Stubs ───

--- a/src/test/java/seedu/address/logic/parser/TagPoolCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TagPoolCommandParserTest.java
@@ -39,9 +39,17 @@ public class TagPoolCommandParserTest {
     }
 
     @Test
-    public void parse_noPrefixes_throwsParseException() {
-        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                TagPoolCommand.MESSAGE_USAGE), () -> parser.parse(""));
+    public void parse_noPrefixes_returnsListMode() throws Exception {
+        TagPoolCommand expected = new TagPoolCommand();
+        TagPoolCommand result = parser.parse("");
+        assert(expected.equals(result));
+    }
+
+    @Test
+    public void parse_blankArgs_returnsListMode() throws Exception {
+        TagPoolCommand expected = new TagPoolCommand();
+        TagPoolCommand result = parser.parse("   ");
+        assert(expected.equals(result));
     }
 
     @Test


### PR DESCRIPTION
Allow tagpool command to display all existing tags when invoked without arguments.

- List tags in alphabetical order
- Show tag count with correct grammar
- Provide empty state message when no tags exist

Improves usability and discoverability of the tag system

Closes #179 .