### PR TITLE
Clarify index range wording in error messages

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -14,7 +14,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INDEX_OUT_OF_RANGE =
             "Error: Index %1$d is out of range. The current list has %2$d candidate(s). "
-            + "Please provide an index between 1 and %2$d.";
+            + "Please provide an index from 1 to %2$d.";
     public static final String MESSAGE_EMPTY_LIST =
             "Error: The candidate list is currently empty. "
             + "There are no candidates to perform this action on.";

--- a/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
@@ -30,7 +30,7 @@ public class DeleteNoteCommand extends Command {
 
     public static final String MESSAGE_INVALID_NOTE_INDEX =
             "Error: Note index %1$d is out of range. Candidate %2$s has %3$d note(s). "
-            + "Please provide a note index between 1 and %3$d.";
+            + "Please provide a note index from 1 to %3$d.";
 
     private static final Logger logger = LogsCenter.getLogger(DeleteNoteCommand.class);
 

--- a/src/main/java/seedu/address/logic/commands/DeleteRejectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteRejectCommand.java
@@ -35,7 +35,7 @@ public class DeleteRejectCommand extends Command {
 
     public static final String MESSAGE_INVALID_REJECT_INDEX =
             "Error: Rejection index %1$d is out of range. Candidate %2$s has %3$d rejection(s). "
-            + "Please provide a rejection index between 1 and %3$d.";
+            + "Please provide a rejection index from 1 to %3$d.";
 
     private static final Logger logger = LogsCenter.getLogger(DeleteRejectCommand.class);
 

--- a/src/main/java/seedu/address/logic/commands/EditNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditNoteCommand.java
@@ -35,7 +35,7 @@ public class EditNoteCommand extends Command {
 
     public static final String MESSAGE_INVALID_NOTE_INDEX =
             "Error: Note index %1$d is out of range. Candidate %2$s has %3$d note(s). "
-            + "Please provide a note index between 1 and %3$d.";
+            + "Please provide a note index from 1 to %3$d.";
 
     private static final Logger logger = LogsCenter.getLogger(EditNoteCommand.class);
 

--- a/src/main/java/seedu/address/logic/commands/EditRejectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditRejectCommand.java
@@ -35,7 +35,7 @@ public class EditRejectCommand extends Command {
 
     public static final String MESSAGE_INVALID_REJECT_INDEX =
             "Error: Rejection index %1$d is out of range. Candidate %2$s has %3$d rejection(s). "
-            + "Please provide a rejection index between 1 and %3$d.";
+            + "Please provide a rejection index from 1 to %3$d.";
 
     private static final Logger logger = LogsCenter.getLogger(EditRejectCommand.class);
 

--- a/src/test/java/seedu/address/logic/commands/DeleteNoteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteNoteCommandTest.java
@@ -93,7 +93,7 @@ public class DeleteNoteCommandTest {
         DeleteNoteCommand command = new DeleteNoteCommand(outOfBoundIndex, Index.fromOneBased(1));
         String expectedMessage = String.format(
                 "Error: Index %d is out of range. The current list has %d candidate(s). "
-                + "Please provide an index between 1 and %d.",
+                + "Please provide an index from 1 to %d.",
                 outOfBoundIndex.getOneBased(), model.getFilteredPersonList().size(),
                 model.getFilteredPersonList().size());
         assertCommandFailure(command, model, expectedMessage);

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -249,7 +249,7 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
 
         String expectedMessage = String.format("Error: Index %d is out of range. "
-                        + "The current list has %d candidate(s). Please provide an index between 1 and %d.",
+                        + "The current list has %d candidate(s). Please provide an index from 1 to %d.",
                 outOfBoundIndex.getOneBased(), model.getFilteredPersonList().size(),
                 model.getFilteredPersonList().size());
 
@@ -271,7 +271,7 @@ public class EditCommandTest {
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         String expectedMessage = String.format("Error: Index %d is out of range. "
-                        + "The current list has %d candidate(s). Please provide an index between 1 and %d.",
+                        + "The current list has %d candidate(s). Please provide an index from 1 to %d.",
                 outOfBoundIndex.getOneBased(), model.getFilteredPersonList().size(),
                 model.getFilteredPersonList().size());
 

--- a/src/test/java/seedu/address/logic/commands/EditNoteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditNoteCommandTest.java
@@ -143,7 +143,7 @@ public class EditNoteCommandTest {
                 "content", null);
         String expectedMessage = String.format(
                 "Error: Index %d is out of range. The current list has %d candidate(s). "
-                + "Please provide an index between 1 and %d.",
+                + "Please provide an index from 1 to %d.",
                 outOfBoundIndex.getOneBased(), model.getFilteredPersonList().size(),
                 model.getFilteredPersonList().size());
         assertCommandFailure(command, model, expectedMessage);

--- a/src/test/java/seedu/address/logic/commands/NoteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/NoteCommandTest.java
@@ -66,7 +66,7 @@ public class NoteCommandTest {
         NoteCommand noteCommand = new NoteCommand(outOfBoundIndex, VALID_NOTE);
         String expectedMessage = String.format(
                 "Error: Index %d is out of range. The current list has %d candidate(s). "
-                + "Please provide an index between 1 and %d.",
+                + "Please provide an index from 1 to %d.",
                 outOfBoundIndex.getOneBased(), model.getFilteredPersonList().size(),
                 model.getFilteredPersonList().size());
         assertCommandFailure(noteCommand, model, expectedMessage);
@@ -102,7 +102,7 @@ public class NoteCommandTest {
         NoteCommand noteCommand = new NoteCommand(outOfBoundIndex, VALID_NOTE);
         String expectedMessage = String.format(
                 "Error: Index %d is out of range. The current list has %d candidate(s). "
-                + "Please provide an index between 1 and %d.",
+                + "Please provide an index from 1 to %d.",
                 outOfBoundIndex.getOneBased(), model.getFilteredPersonList().size(),
                 model.getFilteredPersonList().size());
         assertCommandFailure(noteCommand, model, expectedMessage);

--- a/src/test/java/seedu/address/logic/commands/TagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagCommandTest.java
@@ -66,7 +66,7 @@ public class TagCommandTest {
         TagCommand command = new TagCommand(outOfBounds, List.of(), List.of());
         assertCommandFailure(command, model,
                 String.format("Error: Index %d is out of range. The current list has %d candidate(s). "
-                                + "Please provide an index between 1 and %d.",
+                                + "Please provide an index from 1 to %d.",
                         outOfBounds.getOneBased(),
                         model.getFilteredPersonList().size(),
                         model.getFilteredPersonList().size()));
@@ -79,7 +79,7 @@ public class TagCommandTest {
         TagCommand command = new TagCommand(INDEX_SECOND_PERSON, List.of(), List.of());
         assertCommandFailure(command, model,
                 String.format("Error: Index %d is out of range. The current list has %d candidate(s). "
-                                + "Please provide an index between 1 and %d.",
+                                + "Please provide an index from 1 to %d.",
                         INDEX_SECOND_PERSON.getOneBased(), 1, 1));
     }
 


### PR DESCRIPTION
Replace ambiguous "between 1 and X" with "from 1 to X" in index out-of-range error messages so that the bounds are unambiguously inclusive. Updates production strings in Messages, DeleteNoteCommand, DeleteRejectCommand, EditNoteCommand, and EditRejectCommand, plus the matching assertions in their tests.

Fixes #288